### PR TITLE
Fixed Windows support.

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,6 +1,7 @@
 require("source-map-support").install()
 
-{exec, spawn} = require("child_process")
+exec = require("child_process").exec
+spawn = require('cross-spawn-async')
 merge = require("lodash.merge")
 options = require("./options")
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var exe, exec, handlers, index, merge, options, ref, run, spawn,
 
 require("source-map-support").install();
 
-ref = require("child_process"), exec = ref.exec, spawn = ref.spawn;
+ref = require("child_process"), exec = ref.exec;
+spawn = require('cross-spawn-async');
 
 merge = require("lodash.merge");
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "contributors": [],
   "main": "index.js",
   "dependencies": {
+    "cross-spawn-async": "^2.0.0",
     "lodash.merge": "^3.3.2",
     "node-notifier": "^4.3.1",
     "source-map-support": "^0.3.2"


### PR DESCRIPTION
While trying to use [npm-gulp-test](https://github.com/orlin/gulp-npm-test) I found a bug in `childish-process` that is caused by a Node.js issue that relates to `spawn`'s lack of cross-platform support.

This swaps out the built in `spawn` functionality with [node-cross-spawn-async](https://github.com/IndigoUnited/node-cross-spawn-async). So now it works just fine on Windows as well as Mac and Linux!
